### PR TITLE
Added snapcraft.yaml for building snap packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: irccloud-cli # you probably want to 'snapcraft register <name>'
+version: '0.4.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: IRCCloud Command Line Interface
+description: |
+    Command line client for IRCCloud hosted IRC service.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+apps:
+  irccloud-cli:
+    command: bin/ic
+
+parts:
+  irccloud-cli:
+    plugin: nodejs
+    source: .
+


### PR DESCRIPTION
I've written a snapcraft file so that you can build and publish irccloud-cli to the snap store.
Once you add the file to your repo, you'll want to follow the "Share it with your friends" section from https://docs.snapcraft.io/build-snaps/node to get it in the Snap Store.

Then people will be able to do `snap install irccloud-cli` and run `irccloud-cli` on any snap-enabled Linux distribution.  This keeps all of the node dependencies nicely contained, rather than having to have them installed globally.